### PR TITLE
fix(docker): refresh apk packages in prod image to clear CVE-2026-14456

### DIFF
--- a/build/prod/Containerfile
+++ b/build/prod/Containerfile
@@ -30,7 +30,8 @@ WORKDIR /app
 ARG GIT_COMMIT=unknown
 
 # git stays: the sync worker clones/pulls the storage repository at runtime.
-RUN apk add --no-cache tzdata ca-certificates git sqlite wget
+RUN apk upgrade --no-cache && \
+    apk add --no-cache tzdata ca-certificates git sqlite wget
 
 COPY --from=backend-builder /app/server .
 COPY --from=backend-builder /app/frontend/dist ./frontend/dist


### PR DESCRIPTION
## Summary
- `build/prod/Containerfile`'s final `alpine:3.24` stage was frozen with `libcrypto3`/`libssl3` `3.5.7-r0`, vulnerable to CVE-2026-14456 (HIGH, OpenSSL DoS via unbounded memory).
- No newer `3.24.x` image tag exists to bump to (confirmed `alpine:3.24` and `alpine:3.24.1` resolve to the same digest already pinned) - the live apk index already serves the patched `3.5.8-r0`, it's just not baked into the frozen base layer.
- Added `apk upgrade --no-cache` before the existing `apk add` line so the build picks up current package fixes without changing the pinned base digest.

This CVE gate is failing the `docker-build` Trivy check on several open, otherwise-unrelated Dependabot PRs (confirmed on #48 and #52) - this is a blocking prerequisite for clearing that backlog.

## Test plan
- [x] `make build` - image builds; `apk upgrade` output shows `libcrypto3 (3.5.7-r0 -> 3.5.8-r0)` and `libssl3 (3.5.7-r0 -> 3.5.8-r0)`
- [x] `make smoke` - container starts and passes healthcheck
- [ ] CI `docker-build` job's Trivy step goes green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0119Sksm1WejRGSTXhAVcQbn

🤖 Generated with [Claude Code](https://claude.com/claude-code)